### PR TITLE
Fix tag accumulation across questions in bulk_tag_questions (merge mode)

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -43,10 +43,11 @@ class helper {
      */
     public static function bulk_tag_questions(\stdClass $fromform): void {
         global $DB;
-        $tags = $fromform->formtags;
+        $formtags = $fromform->formtags;
         if ($fromform->selectedquestions) {
             $questions = self::get_selected_questions($fromform);
             foreach ($questions as $question) {
+                $tags = $formtags;
                 if (!$fromform->replacetags) {
                     $existingtags = \core_tag_tag::get_item_tags('core_question', 'question', $question->id);
                     foreach ($existingtags as $tag) {

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -44,7 +44,7 @@ final class helper_test extends advanced_testcase {
      * @var \context_course
      */
     public $coursecontext;
-    
+
     public function setUp(): void {
         parent::setUp();
         $category = $this->getDataGenerator()->create_category();
@@ -97,7 +97,7 @@ final class helper_test extends advanced_testcase {
         $updatedtags = \core_tag_tag::get_item_tags('core_question', 'question', $this->question2->id);
         $this->assertNotEmpty($updatedtags);
     }
-    
+
     /**
      * In merge mode (replacetags = 0) each selected question must only receive
      * its own existing tags merged with the submitted tags, never the existing

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -38,11 +38,19 @@ final class helper_test extends advanced_testcase {
      * @var $question2 \stdClass
      */
     public $question2;
+
+    /**
+     * Course context the test questions live in, used to attach tags.
+     * @var \context_course
+     */
+    public $coursecontext;
+    
     public function setUp(): void {
         parent::setUp();
         $category = $this->getDataGenerator()->create_category();
         $course = $this->getDataGenerator()->create_course(['category' => $category->id]);
         $coursecontext = \context_course::instance($course->id);
+        $this->coursecontext = $coursecontext;
         $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $qcat = $generator->create_question_category(['contextid' => $coursecontext->id]);
         $this->question1 = $generator->create_question('multichoice', null, ['category' => $qcat->id]);
@@ -88,6 +96,42 @@ final class helper_test extends advanced_testcase {
 
         $updatedtags = \core_tag_tag::get_item_tags('core_question', 'question', $this->question2->id);
         $this->assertNotEmpty($updatedtags);
+    }
+    
+    /**
+     * In merge mode (replacetags = 0) each selected question must only receive
+     * its own existing tags merged with the submitted tags, never the existing
+     * tags of the other selected questions. Regression test for tag
+     * accumulation across the question loop.
+     *
+     * @covers \qbank_bulktags\helper::bulk_tag_questions
+     */
+    public function test_bulk_tag_questions_no_cross_contamination(): void {
+        $this->resetAfterTest();
+
+        // Give each question a distinct existing tag.
+        \core_tag_tag::set_item_tags('core_question', 'question', $this->question1->id,
+            $this->coursecontext, ['alpha']);
+        \core_tag_tag::set_item_tags('core_question', 'question', $this->question2->id,
+            $this->coursecontext, ['beta']);
+
+        // Add a shared tag to both questions without replacing existing tags.
+        $fromform = (object) [
+            'selectedquestions' => implode(',', [$this->question1->id, $this->question2->id]),
+            'formtags' => ['shared'],
+            'replacetags' => 0,
+        ];
+        helper::bulk_tag_questions($fromform);
+
+        $q1tags = array_values(\core_tag_tag::get_item_tags_array('core_question', 'question', $this->question1->id));
+        $q2tags = array_values(\core_tag_tag::get_item_tags_array('core_question', 'question', $this->question2->id));
+        sort($q1tags);
+        sort($q2tags);
+
+        // Question 1 keeps only its own tag plus the shared one (not 'beta').
+        $this->assertEquals(['alpha', 'shared'], $q1tags);
+        // Question 2 keeps only its own tag plus the shared one (not 'alpha').
+        $this->assertEquals(['beta', 'shared'], $q2tags);
     }
 
     /**


### PR DESCRIPTION
## What this fixes

When several questions are bulk-tagged with **"Replace existing tags" unchecked** (the default), tags leak from one question onto the next. The result is that questions end up with the existing tags of other selected questions, and the last question in the batch accumulates tags from all the earlier ones.

This is the behaviour reported on the plugin directory page (Chun Ting Wong, 10 Dec 2025).

## Root cause

In `classes/helper.php::bulk_tag_questions()`, the tag list was initialised **once before** the loop over the selected questions and never reset. In merge mode each question's existing tags were appended to that same shared list, so it grew with every iteration.

## The fix

Re-initialise the per-question tag list from the submitted form tags **inside** the loop, so each question only ever gets its own existing tags merged with the submitted ones. One-line change plus a renamed variable; the array is copied by value, so each iteration is isolated.

## Behaviour, before vs after

Three questions with existing tags `Q1=[alpha]`, `Q2=[beta]`, `Q3=[gamma]`, adding `delta` in merge mode:

| | before | after |
|---|---|---|
| Q1 | delta, alpha | delta, alpha |
| Q2 | delta, alpha, beta | delta, beta |
| Q3 | delta, alpha, beta, gamma | delta, gamma |

## Tests

Adds `test_bulk_tag_questions_no_cross_contamination`, which gives two questions distinct existing tags, bulk-adds a shared tag in merge mode, and asserts that neither question receives the other's tag. The result is order-independent: it fails on the current code regardless of the order `get_selected_questions()` returns rows, and passes with the fix.

The pre-existing `test_bulk_tag_questions` only asserted that tags are non-empty after tagging, so it did not detect this. I left it untouched and added a dedicated test rather than modifying it, to keep the change focused.

## Scope / other branches

The affected method is byte-identical on `develop`, so the same patch applies there. The `main_m45` (Moodle 4.5) branch has the same logic and the same bug; only the method signature differs slightly (no `\stdClass` type hint, no `global $DB;`), so the one-line change ports directly. Happy to open separate PRs for those branches if you prefer — just let me know which targets you want.