### PR TITLE
Fix capability check context in tag.php for main + add teacher Behat test

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -47,10 +47,10 @@ if ($cmid) {
     [$module, $cm] = get_module_from_cmid($cmid);
 
     require_login($cm->course, false, $cm);
-    $thiscontext = context_system::instance();
+    $thiscontext = context_module::instance($cmid);
 } else if ($courseid) {
     require_login($courseid, false);
-    $thiscontext = context_system::instance();
+    $thiscontext = context_course::instance($courseid);
 } else {
     throw new moodle_exception('missingcourseorcmid', 'question');
 }

--- a/tests/behat/bulk_tags.feature
+++ b/tests/behat/bulk_tags.feature
@@ -12,9 +12,6 @@ Feature: Use the qbank plugin manager page for bulkmove
     And the following "course enrolments" exist:
           | user     | course | role           |
           | teacher1 | C1     | editingteacher |
-    And the following "course enrolments" exist:
-          | user     | course | role           |
-          | teacher1 | C1     | editingteacher |
     And the following "activities" exist:
           | activity | name            | course | idnumber |
           | quiz     | Test quiz       | C1     | quiz1    |
@@ -47,3 +44,19 @@ Feature: Use the qbank plugin manager page for bulkmove
     And I click on "First question" "checkbox"
     And I click on "With selected" "button"
     And I should see question bulk action "bulktags"
+
+  @javascript
+  Scenario: Teacher can bulk tag questions in quiz question bank
+    Given I log in as "teacher1"
+    And I am on the "Test quiz" "mod_quiz > question bank" page
+    And I set the field "Category" to "Test questions 1 (1)"
+    And I click on "Apply filters" "button"
+    And I click on "First question" "checkbox"
+    And I click on "With selected" "button"
+    And I click on question bulk action "bulktags"
+    And I set the following fields to these values:
+          | Tags | Tag1 |
+    And I press "Save changes"
+    And I choose "Edit question" action for "First question" in the question bank
+    And I expand all fieldsets
+    And I should see "Tag1"


### PR DESCRIPTION
Fixes #3 on `main` branch.
- Updated `tag.php` to use `context_module::instance($cmid)` and `context_course::instance($courseid)` instead of `context_system::instance()`.
- Added a Behat test scenario (`Teacher can bulk tag questions in quiz question bank`) to verify non-admin capability execution.